### PR TITLE
#1 Fixed issue with tiles not appearing

### DIFF
--- a/course-project-cheakmate/public/game.html
+++ b/course-project-cheakmate/public/game.html
@@ -46,13 +46,13 @@
 					/*Image decider*/
 					if(board[i][j] == null){
 						if ( (i*10+j)%2 == 0 && alternate) {
-							square.innerHTML  = '<img src = "images/tile_grey.png">';
+							square.innerHTML  = '<img src = "images/sprites/d.png">';
 						}else if ((i*10+j)%2 == 0 && !alternate){
-							square.innerHTML  = '<img src = "images/tile_brown.png">';
+							square.innerHTML  = '<img src = "images/sprites/l.png">';
 						}else if (alternate){
-							square.innerHTML  = '<img src = "images/tile_brown.png">';
+							square.innerHTML  = '<img src = "images/sprites/l.png">';
 						}else{
-							square.innerHTML  = '<img src = "images/tile_grey.png">';
+							square.innerHTML  = '<img src = "images/sprites/d.png">';
 						}
 					}
 					/*Insert if condition if the square isn't null*/


### PR DESCRIPTION
Chess board tiles did not appear since its name was changed to d.png and
l.ong within new folders. Changed the name of the image when creating
the board so the board is not full of error symbols